### PR TITLE
Prevent .env from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Sensitive files
+.env


### PR DESCRIPTION
The database url is exposed to the public and it might be dangerous based on the situation you have. It's always better to keep .env file not being committed on GitHub. Instead provide an example .env file or if you want to use with GitHub actions then use GitHub secrets.